### PR TITLE
feat: enhance clustering and add hourly sentiment endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,11 @@ from .models import (
 )
 from .news_fetcher import get_articles, periodic_feed_update
 from .reach import cluster_with_labels, get_or_load_similarity_model
-from .sentiment import get_or_load_sentiment_model, sentiment_counts
+from .sentiment import (
+    get_or_load_sentiment_model,
+    sentiment_counts,
+    get_sentiment_trends,
+)
 
 # ──────────────────────────────────────────────────────────────────────────
 # Logging
@@ -217,6 +221,15 @@ async def list_articles(
 @app.get("/analytics/sentiment", response_model=SentimentSummary, tags=["analytics"])
 async def sentiment_endpoint(articles: List[Article] = Depends(_articles_dep)):
     return await sentiment_counts(articles, ml_models["sentiment"])
+
+
+@app.get("/analytics/sentiment/hourly", tags=["analytics"])
+async def sentiment_hourly_endpoint(
+    hours: int = Query(24, ge=1, le=168),
+    articles: List[Article] = Depends(_articles_dep),
+):
+    """Return sentiment counts grouped by hour for the last ``hours`` period."""
+    return await get_sentiment_trends(articles, time_window_hours=hours)
 
 
 @app.get("/analytics/reach", response_model=List[ReachCluster], tags=["analytics"])

--- a/app/reach.py
+++ b/app/reach.py
@@ -1,7 +1,9 @@
 # app/reach.py
 from typing import List, Tuple
 import asyncio
+import numpy as np
 from sklearn.cluster import AgglomerativeClustering
+from sklearn.metrics.pairwise import cosine_similarity
 from sentence_transformers import SentenceTransformer
 import torch
 
@@ -25,20 +27,27 @@ async def get_or_load_similarity_model() -> SentenceTransformer:
 async def cluster_with_labels(
     articles: List[Article],
     distance_threshold: float = 0.6,
+    use_description: bool = True,
 ) -> Tuple[List[ReachCluster], list[int]]:
-    """
-    Returns (clusters, label_for_each_article)
+    """Cluster articles by semantic similarity.
+
+    Returns a tuple of (clusters, label_for_each_article).
     """
     if not articles:
         return [], []
 
     model  = await get_or_load_similarity_model()
+    # Include description text for richer clustering if available
     titles = [a.title for a in articles]
+    if use_description:
+        texts = [f"{a.title} {a.description}".strip() for a in articles]
+    else:
+        texts = titles
 
     # run blocking encode() off the event-loop
     embeds = await asyncio.to_thread(
         model.encode,
-        titles,
+        texts,
         show_progress_bar=False,
         convert_to_numpy=True
     )
@@ -50,18 +59,30 @@ async def cluster_with_labels(
         linkage="average",
     ).fit(embeds)
 
-    # group articles per label
-    clusters_dict: dict[int, List[str]] = {}
-    for lbl, title in zip(clustering.labels_, titles):
-        clusters_dict.setdefault(lbl, []).append(title)
+    # group article indices per label
+    clusters_dict: dict[int, List[int]] = {}
+    for idx, lbl in enumerate(clustering.labels_):
+        clusters_dict.setdefault(lbl, []).append(idx)
 
     clusters: List[ReachCluster] = []
-    for cluster_titles in clusters_dict.values():
+    for indices in clusters_dict.values():
+        cluster_embeds = embeds[indices]
+        # average pairwise similarity; 1.0 for single-item clusters
+        if len(indices) > 1:
+            sim_matrix = cosine_similarity(cluster_embeds)
+            avg_sim = float((np.sum(sim_matrix) - len(indices)) / (len(indices) * (len(indices) - 1)))
+            centroid_idx = indices[int(np.argmax(sim_matrix.mean(axis=1)))]
+        else:
+            avg_sim = 1.0
+            centroid_idx = indices[0]
+
+        cluster_titles = [titles[i] for i in indices]
         clusters.append(
             ReachCluster(
-                centroid_title=max(cluster_titles, key=len),
-                size=len(cluster_titles),
+                centroid_title=titles[centroid_idx],
+                size=len(indices),
                 titles=cluster_titles,
+                similarity_score=avg_sim,
             )
         )
 

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,9 @@ Health checks: Detailed health monitoring endpoints
 
 Background tasks: Automatic feed updates
 
+4. Richer Clustering (reach.py)
+Description-aware embeddings for clustering and similarity scoring for each cluster
+
 API improvements: Better pagination, filtering, and response models
 
 4. Advanced Sentiment Analysis (sentiment.py)
@@ -151,7 +154,9 @@ GET /articles - Get articles with pagination and filtering
 Analytics Endpoints
 GET /analytics/sentiment - Overall sentiment summary
 
-GET /analytics/reach - Content clustering analysis
+GET /analytics/sentiment/hourly - Hourly sentiment counts for recent articles
+
+GET /analytics/reach - Content clustering analysis with similarity scores
 
 GET /analytics/trend - Trend analysis with ratios
 


### PR DESCRIPTION
## Summary
- enrich clustering by using article descriptions, returning average similarity scores
- add API endpoint for hourly sentiment trends
- document new analytics endpoints and clustering improvements

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6534db618832da4203b649dabad22