### PR TITLE
feat: add endpoint to inspect full cache

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 
 # ── local imports ────────────────────────────────────────────────────────
-from .cache import default_cache
+from .cache import default_cache, get_all_cached_data
 from .models import (
     APIResponse,
     Article,
@@ -160,6 +160,12 @@ async def debug_clear_cache():
     """Erase the cached article list manually."""
     await default_cache.delete("articles")
     return {"message": "cache cleared"}
+
+
+@debug.get("/cache/all")
+async def debug_get_all_cache():
+    """Return the full contents of all configured caches."""
+    return await get_all_cached_data()
 
 
 app.include_router(debug)


### PR DESCRIPTION
## Summary
- expose utility to dump all cache entries
- add `/__debug/cache/all` debug endpoint to return contents of all caches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8dae8fb04832d917d3fac8144c409