### PR TITLE
Add API endpoint for news retrieval by source

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -218,6 +218,18 @@ async def list_articles(
     return articles[offset : offset + limit]
 
 
+@app.get("/articles/source/{source}", response_model=List[Article], tags=["content"])
+async def list_articles_by_source(
+    source: str,
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    articles: List[Article] = Depends(_articles_dep),
+):
+    """Return articles from a specific source."""
+    filtered = [a for a in articles if source.lower() in a.source.lower()]
+    return filtered[offset : offset + limit]
+
+
 @app.get("/analytics/sentiment", response_model=SentimentSummary, tags=["analytics"])
 async def sentiment_endpoint(articles: List[Article] = Depends(_articles_dep)):
     return await sentiment_counts(articles, ml_models["sentiment"])

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,8 @@ GET /articles - Get articles with pagination and filtering
 
 ?source=cnn - Filter by source
 
+GET /articles/source/{source} - Fetch articles for a given source with full details
+
 Analytics Endpoints
 GET /analytics/sentiment - Overall sentiment summary
 


### PR DESCRIPTION
## Summary
- add `/articles/source/{source}` endpoint to return articles from a specific source
- document source-based retrieval in README

## Testing
- `python -m py_compile app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8dc284fa8832dbc994c7dce3a83ac